### PR TITLE
Correctly filter personal plates

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -20,19 +20,19 @@
 local TRPKN = select(2, ...);
 
 local function onModuleStart()
-	
+
 	local addon = KuiNameplates;
 	local mod = addon:NewPlugin('Total RP 3: KuiNameplates', 200);
 	local nameTextMod = addon:GetPlugin("NameText");
 	local guildTextMod = addon:GetPlugin("GuildText");
-	
-	
+
+
 	local getConfigValue = TRP3_API.configuration.getValue;
-	
+
 	local isPlayerIC = TRP3_API.dashboard.isPlayerIC;
 	local UnitIsPlayer = UnitIsPlayer;
 	local UnitIsOtherPlayersPet = UnitIsOtherPlayersPet;
-	
+
 	---HideKuiNameplate
 	---@param nameplate Frame
 	function TRPKN.HideKuiNameplate(nameplate)
@@ -41,7 +41,7 @@ local function onModuleStart()
 		nameplate:UpdateNameText();
 		nameplate:UpdateGuildText()
 	end
-	
+
 	---ShowKuiNameplate
 	---@param nameplate Frame
 	function TRPKN.ShowKuiNameplate(nameplate)
@@ -50,8 +50,8 @@ local function onModuleStart()
 		nameplate:UpdateNameText();
 		nameplate:UpdateGuildText();
 	end
-	
-	
+
+
 	---
 	-- Update the nameplate with informations we get from the Total RP 3 API
 	-- @param nameplate
@@ -60,50 +60,50 @@ local function onModuleStart()
 
 		-- TRP3_API.Ellyb.Tables.inspect(nameplate)
 		if not nameplate.unit -- If we don't have a unit
-			or nameplate.state.player --  or this is the personal nameplate
+			or nameplate.state.personal --  or this is the personal nameplate
 			or not nameplate.state.friend -- or this is an enemy
 		then
 			return -- we can stop here
 		end;
-		
+
 		nameTextMod:Show(nameplate);
 		guildTextMod:Show(nameplate);
 		TRPKN.ShowKuiNameplate(nameplate);
-		
+
 		-- Only continue if the customization has not be disabled manually and check if we are in character if the option is checked
 		if not getConfigValue(TRPKN.CONFIG.ENABLE_NAMEPLATES_CUSTOMIZATION) or (getConfigValue(TRPKN.CONFIG.DISPLAY_NAMEPLATES_ONLY_IN_CHARACTER) and not isPlayerIC()) then
 			return
 		end;
-		
+
 		if getConfigValue(TRPKN.CONFIG.HIDE_NON_ROLEPLAY) and UnitIsPlayer(nameplate.unit) or UnitIsOtherPlayersPet(nameplate.unit) then
 			TRPKN.HideKuiNameplate(nameplate);
 		end
-		
+
 		-- Check if the unit is a player)
 		if UnitIsPlayer(nameplate.unit) then
 			TRPKN.modifyPlayerNameplate(nameplate);
 		else
 			TRPKN.modifyPetNameplate(nameplate);
 		end
-	
-	
+
+
 	end
-	
+
 	function TRPKN.refreshAllNameplates()
 		for _, nameplate in addon:Frames() do
 			mod:UpdateRPName(nameplate);
 		end
 	end
-	
+
 	mod.RefreshAllNameplates = TRPKN.refreshAllNameplates;
-	
+
 	function mod:Initialise()
 		self:RegisterMessage('Create', 'RefreshAllNameplates');
 		self:RegisterMessage('Show', 'UpdateRPName');
 		self:RegisterMessage('GainedTarget', 'UpdateRPName');
 		self:RegisterMessage('LostTarget', 'UpdateRPName');
 	end
-	
+
 	-- We listen to the register data update event fired by Total RP 3 when we receive new data
 	-- about a player.
 	-- It's not super efficient, but we will refresh all RP names on all nameplates for now


### PR DESCRIPTION
Fixes #8. Personal plates use `state.personal` and not `state.player`.

Users on recent versions of KuiNameplates will have correct functionality, but users on older versions might now get their personal plate decorated as a result. It could also be that `state.personal` has been around for a while anyway though.

Some whitespace got cleaned up too. My editor takes no prisoners.